### PR TITLE
libby2trilium

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,13 +330,13 @@ Programs based on triliums ETAPI.
 
 * [omnivore2trilium](https://github.com/0xbismarck/omnivore2trilium) ![omnivore2trilium](https://img.shields.io/github/last-commit/0xbismarck/omnivore2trilium)
   A tool that imports highlights directly into Trilium from [Omnivore](https://omnivore.app/), a Read-It-Later App.
+* [trilium-blog](https://github.com/harveyTon/trilium-blog) ![trilium-blog](https://img.shields.io/github/last-commit/harveyTon/trilium-blog) A modern and lightweight blog system based on Trilium Notes, supporting Vue 3 front-end and Go back-end, deployed using Docker.
 * [trilium-bot](https://github.com/Nriver/trilium-bot) ![trilium-bot](https://img.shields.io/github/last-commit/Nriver/trilium-bot)
 * [Trilium2typecho](https://gitee.com/gkm0/trilium2typecho)
   Sync Trilium Notes to typecho automatically.
   A demo Telegram bot for Trilium, powered by [trilium-py](https://github.com/Nriver/trilium-py).
 * [zotero-trilium](https://github.com/paulusm/zotero-trilium) ![zotero-trilium](https://img.shields.io/github/last-commit/paulusm/zotero-trilium)
 Add-on for Zotero reference manager, lets you export formatted references and notes across to Trilium.
-* [trilium-blog](https://github.com/harveyTon/trilium-blog) ![trilium-blog](https://img.shields.io/github/last-commit/harveyTon/trilium-blog) A modern and lightweight blog system based on Trilium Notes, supporting Vue 3 front-end and Go back-end, deployed using Docker.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -328,6 +328,8 @@ The client implementations for ETAPI.
 
 Programs based on triliums ETAPI.
 
+* [libby2trilium](https://github.com/0xbismarck/libby2trilium) ![libby2trilium](https://img.shields.io/github/last-commit/0xbismarck/libby2trilium)
+  Import your book highlights and notes from [Libby](https://libbyapp.com/) into Trilium Notes.
 * [omnivore2trilium](https://github.com/0xbismarck/omnivore2trilium) ![omnivore2trilium](https://img.shields.io/github/last-commit/0xbismarck/omnivore2trilium)
   A tool that imports highlights directly into Trilium from [Omnivore](https://omnivore.app/), a Read-It-Later App.
 * [trilium-blog](https://github.com/harveyTon/trilium-blog) ![trilium-blog](https://img.shields.io/github/last-commit/harveyTon/trilium-blog) 

--- a/README.md
+++ b/README.md
@@ -330,13 +330,14 @@ Programs based on triliums ETAPI.
 
 * [omnivore2trilium](https://github.com/0xbismarck/omnivore2trilium) ![omnivore2trilium](https://img.shields.io/github/last-commit/0xbismarck/omnivore2trilium)
   A tool that imports highlights directly into Trilium from [Omnivore](https://omnivore.app/), a Read-It-Later App.
-* [trilium-blog](https://github.com/harveyTon/trilium-blog) ![trilium-blog](https://img.shields.io/github/last-commit/harveyTon/trilium-blog) A modern and lightweight blog system based on Trilium Notes, supporting Vue 3 front-end and Go back-end, deployed using Docker.
+* [trilium-blog](https://github.com/harveyTon/trilium-blog) ![trilium-blog](https://img.shields.io/github/last-commit/harveyTon/trilium-blog) 
+  A modern and lightweight blog system based on Trilium Notes, supporting Vue 3 front-end and Go back-end, deployed using Docker.
 * [trilium-bot](https://github.com/Nriver/trilium-bot) ![trilium-bot](https://img.shields.io/github/last-commit/Nriver/trilium-bot)
 * [Trilium2typecho](https://gitee.com/gkm0/trilium2typecho)
   Sync Trilium Notes to typecho automatically.
   A demo Telegram bot for Trilium, powered by [trilium-py](https://github.com/Nriver/trilium-py).
 * [zotero-trilium](https://github.com/paulusm/zotero-trilium) ![zotero-trilium](https://img.shields.io/github/last-commit/paulusm/zotero-trilium)
-Add-on for Zotero reference manager, lets you export formatted references and notes across to Trilium.
+  Add-on for Zotero reference manager, lets you export formatted references and notes across to Trilium.
 
 ---
 


### PR DESCRIPTION
Adding link to new Python tool, libby2trilium, which imports your reading notes into a new Trilium note. 