### PR TITLE
Add trilium-ai-agent (AI chat widget for share pages)

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,8 @@ Remember, scripts are executable codes. Handle with caution!
   a MOTD(Message of the day) message :)
 * [Trillium Agenda](https://github.com/BeatLink/trilium-agenda) ![Trillium Agenda](https://img.shields.io/github/last-commit/BeatLink/trilium-agenda)
   Sorts todos into 6 categories: Overdue, Today, This Week, This Month, This Year, Future
+* [trilium-ai-agent](https://github.com/mrbeandev/trilium-ai-agent) ![trilium-ai-agent](https://img.shields.io/github/last-commit/mrbeandev/trilium-ai-agent)
+  AI chat widget for Trilium **share pages** (public docs). Drop-in `~shareJs` script that adds a floating "Ask the docs" bubble — the AI uses tool calls to navigate your whole shared note tree. Works with any OpenAI-compatible API (Gemini, OpenAI, OpenRouter, …).
 * [Trilium-chat](https://github.com/soulsands/trilium-chat) ![Trilium-chat](https://img.shields.io/github/last-commit/soulsands/trilium-chat)
   Allows interaction with ChatGPT and Ollama conveniently right inside of Trilium.
 * [Trilium-DailyMood](https://github.com/dvai/Trilium-DailyMood) ![Trilium-DailyMood](https://img.shields.io/github/last-commit/dvai/Trilium-DailyMood)


### PR DESCRIPTION
Adds [trilium-ai-agent](https://github.com/mrbeandev/trilium-ai-agent) under **Scripts**.

A drop-in `~shareJs` widget that turns any TriliumNext share page into an AI-assisted docs site. The AI uses tool calls (`search_notes`, `read_note`) to navigate the shared note tree and answer visitor questions. Works with any OpenAI-compatible API (Gemini, OpenAI, OpenRouter, DeepSeek, local Ollama, …). Single JS file, no build step, MIT.

Sits alongside `Trilium-chat` in the Scripts section but addresses a different use case — the public share-page experience rather than in-app chat.