### PR TITLE
Add Suppr Zotero Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,8 @@ Development tools for developing Trilium and its plugins.
 
 ## 🌐 Translation
 
+- [Suppr Zotero Plugin](https://github.com/WildDataX/suppr-zotero-plugin) - Zotero plugin for translating titles, abstracts, PDFs, and research documents in Suppr workflows.
+
 Third-party translation for Trilium Notes.
 
 * [trilium-translation](https://github.com/Nriver/trilium-translation) ![trilium-translation](https://img.shields.io/github/last-commit/Nriver/trilium-translation)


### PR DESCRIPTION
Hi, thanks for maintaining this resource list.

This PR adds Suppr Zotero Plugin. Zotero plugin for translating titles, abstracts, PDFs, and research documents in Suppr workflows.

- Source: https://github.com/WildDataX/suppr-zotero-plugin
- Docs: https://github.com/WildDataX/suppr-zotero-plugin#readme

Disclosure: I am affiliated with Suppr/WildDataX, so I kept the entry concise and used official source/docs links only.