### PR TITLE
Add Solarized Dark & Light theme for Trilium Next

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ which indicates the name of the theme displayed in Trilium's options panel.
       Green color version of Obsidian Theme
 * [Solarized theme](https://github.com/WKSu/trilium-solarized-theme) ![Solarized theme](https://img.shields.io/github/last-commit/WKSu/trilium-solarized-theme)
   Brings the classic solarized themes to Trilium! It comes in both light and dark.
+  * [Solarized Dark & Light Theme](https://github.com/calico-cat-3333/trilium-next-solarized-theme) ![Solarized Dark & Light 主题](https://img.shields.io/github/last-commit/calico-cat-3333/trilium-next-solarized-theme) A modified version of the Solarized theme for a better experience with Trilium Next.
 * [Stellar Dark Theme](https://github.com/Lolabird/stellar-dark-theme-trilium) ![Stellar Dark Theme](https://img.shields.io/github/last-commit/Lolabird/stellar-dark-theme-trilium)
   A different taste of dark theme.
 * [VOID Theme](https://github.com/DikshantJangra/void-trilium-theme) A pure black, borderless minimal dark theme for TriliumNext.

--- a/README_CN.md
+++ b/README_CN.md
@@ -122,6 +122,8 @@
     
 * [Solarized 主题](https://github.com/WKSu/trilium-solarized-theme) ![Solarized 主题](https://img.shields.io/github/last-commit/WKSu/trilium-solarized-theme)
   将经典的 Solarized 主题带到 Trilium 中！提供浅色和深色两种版本。
+
+  * [Solarized Dark & Light 主题](https://github.com/calico-cat-3333/trilium-next-solarized-theme) ![Solarized Dark & Light 主题](https://img.shields.io/github/last-commit/calico-cat-3333/trilium-next-solarized-theme) Solarized 主题的修改版本，以更好地支持 Trilium Next.
   
 * [星际黑暗主题](https://github.com/Lolabird/stellar-dark-theme-trilium) ![星际黑暗主题](https://img.shields.io/github/last-commit/Lolabird/stellar-dark-theme-trilium)
   一款不同风格的深色主题。


### PR DESCRIPTION
The old version of the Solarized theme has not been updated for a long time and does not work well with Trilium Next.

This is my modified version, with better support for Trilium Next's modern theme.

<img width="1920" height="1039" alt="dark" src="https://github.com/user-attachments/assets/dbd233b6-6a2d-490c-b85b-3a15e90894af" />
<img width="1920" height="1039" alt="light" src="https://github.com/user-attachments/assets/72b300cc-584d-42fd-9fb3-166d40f10d2a" />
